### PR TITLE
Update community server host to new address

### DIFF
--- a/t2csri/community/settings.cs
+++ b/t2csri/community/settings.cs
@@ -7,7 +7,7 @@
 
 // This file contains the URL and server settings for the community system.
 
-$TribesNext::Community::Host = "thyth.com";
+$TribesNext::Community::Host = "tribesnext.thyth.com";
 $TribesNext::Community::Port = 80;
 $TribesNext::Community::BaseURL = "/tn/robot/";
 


### PR DESCRIPTION
Switching from "thyth.com" to "tribesnext.thyth.com" for impending service move.